### PR TITLE
Update Java and Python sample application to use Arrow 3.0.0

### DIFF
--- a/.github/workflows/python-workflow.yaml
+++ b/.github/workflows/python-workflow.yaml
@@ -39,7 +39,7 @@ jobs:
       matrix:
         # PyArrow is currently not compatible with Python 3.9
         # See: https://arrow.apache.org/docs/python/install.html#python-compatibility
-        python-version: [3.5, 3.6, 3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     services:
       dremio:

--- a/.github/workflows/python-workflow.yaml
+++ b/.github/workflows/python-workflow.yaml
@@ -67,17 +67,13 @@ jobs:
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # Exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
           flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-      # Below test steps are temporarily turned off until Python sample client application is
-      # updated to use Arrow Flight Auth2 authentication.
-
-      # Below step can be improved to run a Python or Bash script that checks for Dremio's liveness
-      #- name: Poll for Dremio readiness
-      #  run: |
-      #    python ../readiness_check.py
-      #- name: Test connection to Dremio Arrow Flight server endpoint
-      #  run: |
-      #    pytest test.py -v -s
-      #- name: Print docker logs
-      #  if: ${{ failure() || cancelled() }}
-      #  run: |
-      #    docker logs $(docker ps -aq)
+      - name: Poll for Dremio readiness
+        run: |
+          python ../readiness_check.py
+      - name: Test connection to Dremio Arrow Flight server endpoint
+        run: |
+          pytest test.py -v -s
+      - name: Print docker logs
+        if: ${{ failure() || cancelled() }}
+        run: |
+          docker logs $(docker ps -aq)

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <arrow.version>3.0.0-20201110174718-41d24384a1-dremio</arrow.version>
+        <arrow.version>3.0.0</arrow.version>
     </properties>
 
     <repositories>

--- a/python/requirements.txt
+++ b/python/requirements.txt
@@ -2,4 +2,4 @@
 pandas
 
 ###### Requirements with version specifiers ######
-pyarrow==2.0.0
+pyarrow==3.0.0


### PR DESCRIPTION
- Add detailed comments about Auth2 and client properties usage in Java sample application.
- Update Java sample app to use Arrow 3.0.0.
- Update Python sample app to use Arrow 3.0.0. The example itself is updated to use "Authorization" header authentication as well. This new feature was made available in Arrow 3.0.0.
- PyArrow only supports Python 3.6, 3.7 and 3.8, Github workflow support for Python 3.5 is discontinued.