### PR TITLE
WIP: Fix Python header overwrite

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -1,7 +1,7 @@
 # Python Arrow Flight Client Application Example
 ![Build Status](https://github.com/dremio-hub/arrow-flight-client-examples/workflows/python-build/badge.svg)
 
-This lightweight Python client application connects to the Dremio Arrow Flight server endpoint. Developers can use token based or regular user credentials (username/password) for authentication. Please not username/password is not supported for DCS. Any datasets in Dremio that are accessible by the provided Dremio user can be queried. By default, the hostname is `localhost` and the port is `32010`. Developers can change these default settings by providing the hostname and port as arguments when running the client.
+This lightweight Python client application connects to the Dremio Arrow Flight server endpoint. Developers can use token based or regular user credentials (username/password) for authentication. Please note username/password is not supported for DCS. Any datasets in Dremio that are accessible by the provided Dremio user can be queried. By default, the hostname is `localhost` and the port is `32010`. Developers can change these default settings by providing the hostname and port as arguments when running the client.
 Moreover, the tls option can be provided to establish an encrypted connection.
 
 ### Instructions on using this Python sample application

--- a/python/README.md
+++ b/python/README.md
@@ -1,7 +1,7 @@
 # Python Arrow Flight Client Application Example
 ![Build Status](https://github.com/dremio-hub/arrow-flight-client-examples/workflows/python-build/badge.svg)
 
-This lightweight Python client application connects to the Dremio Arrow Flight server endpoint. Developers can use token based or regular user credentials (username/password) for authentication. Any datasets in Dremio that are accessible by the provided Dremio user can be queried. By default, the hostname is `localhost` and the port is `32010`. Developers can change these default settings by providing the hostname and port as arguments when running the client.
+This lightweight Python client application connects to the Dremio Arrow Flight server endpoint. Developers can use token based or regular user credentials (username/password) for authentication. Please not username/password is not supported for DCS. Any datasets in Dremio that are accessible by the provided Dremio user can be queried. By default, the hostname is `localhost` and the port is `32010`. Developers can change these default settings by providing the hostname and port as arguments when running the client.
 Moreover, the tls option can be provided to establish an encrypted connection.
 
 ### Instructions on using this Python sample application
@@ -39,7 +39,7 @@ optional arguments:
   -certs TRUSTED_CERTIFICATES, --trustedCertificates TRUSTED_CERTIFICATES
                         Path to trusted certificates for encrypted connection. Defaults to system certificates.
   -sessionProperties [SESSION_PROPERTIES ...], --sessionProperties [SESSION_PROPERTIES ...]
-                        Key value pairs of SessionProperty, example: -session_properties key1=value1 key2=value2
+                        Key value pairs of SessionProperty, example: -sessionProperties schema='Samples."samples.dremio.com"'
   -engine ENGINE, --engine ENGINE
                         The specific engine to run against.
 ```

--- a/python/example.py
+++ b/python/example.py
@@ -213,8 +213,8 @@ def connect_to_dremio_flight_server_endpoint(host, port, username, password, que
             # Authenticate with the server endpoint.
             bearer_token = client.authenticate_basic_token(username, password,
                                                            flight.FlightCallOptions(headers=headers))
-            headers = [bearer_token]
             print('[INFO] Authentication was successful')
+            headers.append(bearer_token)
         else:
             print('[ERROR] Username/password or PAT/Auth token must be supplied.')
             sys.exit()


### PR DESCRIPTION
When using username/password for authentication, the bearer token would overwrite all existing headers.