### PR TITLE
Fix engine header for Java/Python. Fix header passing for Java

### DIFF
--- a/java/src/main/java/com/adhoc/flight/SessionPropertyConverter.java
+++ b/java/src/main/java/com/adhoc/flight/SessionPropertyConverter.java
@@ -24,7 +24,7 @@ import com.beust.jcommander.IStringConverter;
 public class SessionPropertyConverter implements IStringConverter<SessionProperty> {
   @Override
   public SessionProperty convert(String keyValuePair) {
-    final String[] parts = keyValuePair.split(":");
+    final String[] parts = keyValuePair.split("=");
 
     final String key = parts[0].trim();
     final String value = parts[1].trim();

--- a/java/src/test/java/com/adhoc/flight/TestAdhocFlightClient.java
+++ b/java/src/test/java/com/adhoc/flight/TestAdhocFlightClient.java
@@ -17,6 +17,9 @@
 
 package com.adhoc.flight;
 
+import static com.adhoc.flight.QueryRunner.KEY_ROUTING_QUEUE;
+import static com.adhoc.flight.QueryRunner.KEY_ROUTING_TAG;
+import static com.adhoc.flight.QueryRunner.KEY_SCHEMA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -59,9 +62,6 @@ public class TestAdhocFlightClient {
   public static final String SIMPLE_QUERY = "select * from (VALUES(1,2,3),(4,5,6))";
   public static final boolean DISABLE_SERVER_VERIFICATION = true;
 
-  public static final String KEY_SCHEMA_PATH = "SCHEMA";
-  public static final String KEY_ROUTING_TAG = "ROUTING_TAG";
-  public static final String KEY_ROUTING_QUEUE = "ROUTING_QUEUE";
   public static final String DEFAULT_SCHEMA_PATH = "$scratch";
   public static final String DEFAULT_ROUTING_TAG = "test-routing-tag";
   public static final String DEFAULT_ROUTING_QUEUE = "Low Cost User Queries";
@@ -168,7 +168,6 @@ public class TestAdhocFlightClient {
   public void testSimpleQueryWithClientPropertiesDuringAuth() throws Exception {
     // Create HeaderCallOption to transport Dremio client properties.
     final CallHeaders callHeaders = new FlightCallHeaders();
-    callHeaders.insert(KEY_SCHEMA_PATH, DEFAULT_SCHEMA_PATH);
     callHeaders.insert(KEY_ROUTING_TAG, DEFAULT_ROUTING_TAG);
     callHeaders.insert(KEY_ROUTING_QUEUE, DEFAULT_ROUTING_QUEUE);
     final HeaderCallOption clientProperties = new HeaderCallOption(callHeaders);
@@ -177,10 +176,10 @@ public class TestAdhocFlightClient {
     createBasicFlightClient(HOST, PORT, USERNAME, PASSWORD, null, clientProperties);
 
     // Create table
-    client.runQuery(CREATE_TABLE_NO_SCHEMA, null, null, false);
+    client.runQuery(CREATE_TABLE, null, null, false);
 
     // Select
-    client.runQuery(SIMPLE_QUERY_NO_SCHEMA, null, null, false);
+    client.runQuery(SIMPLE_QUERY, null, null, false);
 
     // Drop table
     client.runQuery(DROP_TABLE, null, null, false);
@@ -188,17 +187,17 @@ public class TestAdhocFlightClient {
 
   @Test
   public void testSimpleQueryWithDefaultSchemaPath() throws Exception {
+    final CallHeaders callHeaders = new FlightCallHeaders();
+    callHeaders.insert(KEY_SCHEMA, DEFAULT_SCHEMA_PATH);
+    final HeaderCallOption callOption = new HeaderCallOption(callHeaders);
     // Create FlightClient connecting to Dremio.
     createBasicFlightClient(HOST, PORT, USERNAME, PASSWORD, null);
 
     // Create table
-    client.runQuery(CREATE_TABLE, null, null, false);
+    client.runQuery(CREATE_TABLE, callOption, null, false);
 
     // Select
-    final CallHeaders callHeaders = new FlightCallHeaders();
-    callHeaders.insert(KEY_SCHEMA_PATH, DEFAULT_SCHEMA_PATH);
-    final HeaderCallOption callOption = new HeaderCallOption(callHeaders);
-    client.runQuery(SIMPLE_QUERY_NO_SCHEMA, callOption, null, false);
+    client.runQuery(SIMPLE_QUERY_NO_SCHEMA, null, null, false);
 
     // Drop table
     client.runQuery(DROP_TABLE, null, null, false);

--- a/java/src/test/java/com/adhoc/flight/TestQueryRunner.java
+++ b/java/src/test/java/com/adhoc/flight/TestQueryRunner.java
@@ -28,18 +28,18 @@ import com.beust.jcommander.Parameter;
  * Tests for {@link QueryRunner}. Checking parsing functions.
  */
 public class TestQueryRunner {
-  @Parameter(names = "--sessionProperties", variableArity = true, listConverter = SessionPropertyConverter.class)
+  @Parameter(names = "--sessionProperty", variableArity = true, listConverter = SessionPropertyConverter.class)
   List<SessionProperty> sessionProperties;
 
   @Test
   public void testParseSessionProperties() {
     JCommander jc = new JCommander(this);
-    jc.parse("--sessionProperties", "key1:value1", "key2:value2");
+    jc.parse("--sessionProperty", "schema=\'Samples.\"samples.dremio.com\"\'", "key=value");
     Assert.assertNotNull(sessionProperties);
     Assert.assertEquals(2, sessionProperties.size());
-    Assert.assertEquals("key1", sessionProperties.get(0).getKey());
-    Assert.assertEquals("value1", sessionProperties.get(0).getValue());
-    Assert.assertEquals("key2", sessionProperties.get(1).getKey());
-    Assert.assertEquals("value2", sessionProperties.get(1).getValue());
+    Assert.assertEquals("schema", sessionProperties.get(0).getKey());
+    Assert.assertEquals("\'Samples.\"samples.dremio.com\"\'", sessionProperties.get(0).getValue());
+    Assert.assertEquals("key", sessionProperties.get(1).getKey());
+    Assert.assertEquals("value", sessionProperties.get(1).getValue());
   }
 }

--- a/python/example.py
+++ b/python/example.py
@@ -144,8 +144,8 @@ def parse_arguments():
     parser.add_argument('-certs', '--trustedCertificates', dest='trusted_certificates', type=str,
                         help='Path to trusted certificates for encrypted connection. Defaults to system certificates.',
                         default=certifi.where())
-    parser.add_argument('-sessionProperties', '--sessionProperties', dest='session_properties',
-                        help="Key value pairs of SessionProperty, example: -session_properties key1=value1 key2=value2",
+    parser.add_argument('-sp', '--sessionProperty', dest='session_properties',
+                        help="Key value pairs of SessionProperty, example: -sp schema=\'Samples.\"samples.dremio.com\"' -sp key=value",
                         required=False, nargs='*', action=KVParser)
     parser.add_argument('-engine', '--engine', type=str, help='The specific engine to run against.',
                         required=False)
@@ -187,7 +187,7 @@ def connect_to_dremio_flight_server_endpoint(host, port, username, password, que
             headers = []
 
         if engine:
-            headers.append((b'engine', engine.encode('utf-8')))
+            headers.append((b'routing_engine', engine.encode('utf-8')))
 
         # Two WLM settings can be provided upon initial authentication with the Dremio Server Flight Endpoint:
         # routing_tag


### PR DESCRIPTION
Changed the "engine" header to "routing_engine" for directing queries at specific engines.

Java client SessionProperty settings were not being passed down.