### PR TITLE
Java client - Use system KeyStore by default

### DIFF
--- a/java/src/main/java/com/adhoc/flight/QueryRunner.java
+++ b/java/src/main/java/com/adhoc/flight/QueryRunner.java
@@ -27,7 +27,6 @@ import org.apache.arrow.flight.FlightCallHeaders;
 import org.apache.arrow.flight.HeaderCallOption;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
-import org.apache.arrow.util.Preconditions;
 import org.apache.arrow.vector.VectorSchemaRoot;
 
 import com.adhoc.flight.client.AdhocFlightClient;
@@ -105,7 +104,7 @@ public class QueryRunner {
     public boolean disableServerVerification = false;
 
     @Parameter(names = {"-kstpath", "--keyStorePath"},
-        description = "Path to the jks keystore.")
+        description = "Path to the jks keystore. Defaults to system Keystore.")
     public String keystorePath = null;
 
     @Parameter(names = {"-kstpass", "--keyStorePassword"},
@@ -325,10 +324,6 @@ public class QueryRunner {
     }
 
     if (ARGUMENTS.enableTls) {
-      Preconditions.checkNotNull(ARGUMENTS.keystorePath,
-          "When TLS is enabled, path to the KeyStore is required.");
-      Preconditions.checkNotNull(ARGUMENTS.keystorePass,
-          "When TLS is enabled, the KeyStore password is required.");
       return AdhocFlightClient.getEncryptedClient(BUFFER_ALLOCATOR,
           ARGUMENTS.host, ARGUMENTS.port,
           ARGUMENTS.user, ARGUMENTS.pass,

--- a/java/src/main/java/com/adhoc/flight/client/AdhocFlightClient.java
+++ b/java/src/main/java/com/adhoc/flight/client/AdhocFlightClient.java
@@ -95,7 +95,7 @@ public final class AdhocFlightClient implements AutoCloseable {
                                                      String patOrAuthToken,
                                                      String keyStorePath,
                                                      String keyStorePass,
-                                                     boolean verifyServer,
+                                                     boolean disableServerVerification,
                                                      HeaderCallOption clientProperties,
                                                      List<FlightClientMiddleware.Factory> middlewares)
       throws Exception {
@@ -110,8 +110,12 @@ public final class AdhocFlightClient implements AutoCloseable {
       }
     }
 
-    if (verifyServer) {
+    if (disableServerVerification) {
       flightClientBuilder.verifyServer(false);
+    } else if (Strings.isNullOrEmpty(keyStorePath)) {
+      System.out.println("KeyStore path not provided. Defaulting to system KeyStore.");
+    } else if (Strings.isNullOrEmpty(keyStorePass)) {
+      System.out.println("KeyStore password not provided. Defaulting to system KeyStore.");
     } else {
       flightClientBuilder
         .trustedCertificates(EncryptedConnectionUtils.getCertificateStream(keyStorePath, keyStorePass));


### PR DESCRIPTION
Fix bug where if TLS was enabled, you always had to provide keystorepath and keystorepass.
Only necessary now if you are using a custom/dev KeyStore.