### PR TITLE
Change to the logic around Disable Server Verification

### DIFF
--- a/python/README.md
+++ b/python/README.md
@@ -80,3 +80,9 @@ Running the command will return the following.
 ```
 
 You have now run your first Flight query on Dremio Cloud!
+
+### Note 
+* If you are running Dremio Enterprise on your own infrastructure (i.e. not running on Dremio Cloud) and are using PATs, the PAT must be added as the value to the `-pass` parameter and the `-user` must be specified.
+E.g:
+
+```python3 example.py -host my.dremio.local -port 443 -user dremio -pass '<INSERT PAT HERE>' -tls -query 'SELECT * FROM Samples."samples.dremio.com"."NYC-taxi-trips" limit 10'```

--- a/python/README.md
+++ b/python/README.md
@@ -80,9 +80,3 @@ Running the command will return the following.
 ```
 
 You have now run your first Flight query on Dremio Cloud!
-
-### Note 
-* If you are running Dremio Enterprise on your own infrastructure (i.e. not running on Dremio Cloud) and are using PATs, the PAT must be added as the value to the `-pass` parameter and the `-user` must be specified.
-E.g:
-
-```python3 example.py -host my.dremio.local -port 443 -user dremio -pass '<INSERT PAT HERE>' -tls -query 'SELECT * FROM Samples."samples.dremio.com"."NYC-taxi-trips" limit 10'```

--- a/python/example.py
+++ b/python/example.py
@@ -169,15 +169,15 @@ def connect_to_dremio_flight_server_endpoint(host, port, username, password, que
             # Connect to the server endpoint with an encrypted TLS connection.
             print('[INFO] Enabling TLS connection')
             scheme = "grpc+tls"
-            if certs:
-                print('[INFO] Trusted certificates provided')
-                # TLS certificates are provided in a list of connection arguments.
-                with open(certs, "rb") as root_certs:
-                    connection_args["tls_root_certs"] = root_certs.read()
-            elif disable_server_verification:
+            if disable_server_verification:
                 # Connect to the server endpoint with server verification disabled.
                 print('[INFO] Disable TLS server verification.')
                 connection_args['disable_server_verification'] = disable_server_verification
+            elif certs:
+                print('[INFO] Trusted certificates provided')
+                # TLS certificates are provided in a list of connection arguments.
+                with open(certs, "rb") as root_certs:
+                    connection_args["tls_root_certs"] = root_certs.read()                
             else:
                 print('[ERROR] Trusted certificates must be provided to establish a TLS connection')
                 sys.exit()


### PR DESCRIPTION
For the Python `example.py`

Currently, using the `-dsv True` flag is over-ridden by the `-certs` flag, which, if not provided manually is populated by the system certs by default.

So, before this change, specifying `-dsv True` without specifying an empty set of `-certs` will *not* disable server verification. 
This is counter-intuitive - if I specify dsv, then I expect server verification to be off completely.
As a side note - while it is easy enough on linux to specify an empty set of certs ( `-certs ""`), I have seen that this does not hold true for all OS - e.g. on Windows it is not straightforward, it seems.

Steps to reproduce:
- run the script against a TLS enabled Dremio whose cert is not trusted by the system the script is running on, and include `-dsv True` but do not include a certs parameter.
Result:
- Script will fail with TLS errors because the system certs are being used which do not trust the Dremio cert