### PR TITLE
chore: avoid exponecial computation cost by concatenation inside loop

### DIFF
--- a/python/dremio-flight/dremio/flight/query.py
+++ b/python/dremio-flight/dremio/flight/query.py
@@ -55,13 +55,14 @@ class DremioFlightEndpointQuery:
 
     def _get_chunks(self, reader: flight.FlightStreamReader) -> DataFrame:
         dataframe = DataFrame()
+        chunks = []
         while True:
             try:
                 flight_batch = reader.read_chunk()
                 record_batch = flight_batch.data
                 data_to_pandas = record_batch.to_pandas()
-                dataframe = concat([dataframe, data_to_pandas])
+                chunks.append(data_to_pandas)
             except StopIteration:
                 break
-
-        return dataframe
+        
+        return concat(chunks)


### PR DESCRIPTION
just move concat all chunks at once on return, this avoid exponential cost of concatenation for big dataset