### PR TITLE
Add session option handling to client

### DIFF
--- a/QUICKSTART.md
+++ b/QUICKSTART.md
@@ -94,6 +94,9 @@ optional arguments:
   -user, --username
     Dremio username
     Default: dremio
+  -projectId, --projectId
+    Dremio Cloud project to connect to.
+    Default: default project for organization
 ```
 
 ## Forums

--- a/java/README.md
+++ b/java/README.md
@@ -70,4 +70,7 @@ Arguments:
     -user, --username
       Dremio username.
       Defaults to "dremio".
+    -projectId, --projectId
+      Dremio Cloud project to connect to.
+      Default: default project for organization
 ```

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -65,7 +65,12 @@
             <version>1.10.19</version>
             <scope>test</scope>
         </dependency>
-
+        <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <version>5.13.0</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
 
     <build>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <arrow.version>16.1.0-20240904212746-09241242ea-dremio</arrow.version>
+        <arrow.version>17.0.0</arrow.version>
         <dep.guava.version>33.3.0-jre</dep.guava.version>
         <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     </properties>
@@ -67,16 +67,6 @@
         </dependency>
 
     </dependencies>
-
-    <repositories>
-        <repository>
-            <snapshots>
-                <enabled>false</enabled>
-            </snapshots>
-            <id>dremio-public</id>
-            <url>https://repo.drem.io/content/repositories/internal-releases/</url>
-        </repository>
-    </repositories>
 
     <build>
         <plugins>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,7 +11,7 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <arrow.version>17.0.0</arrow.version>
+        <arrow.version>18.0.0</arrow.version>
         <dep.guava.version>33.3.0-jre</dep.guava.version>
         <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     </properties>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <arrow.version>11.0.0-20240312005600-b6b322df1a-dremio</arrow.version>
-        <dep.guava.version>33.1.0-jre</dep.guava.version>
+        <arrow.version>16.1.0-20240904212746-09241242ea-dremio</arrow.version>
+        <dep.guava.version>33.3.0-jre</dep.guava.version>
         <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     </properties>
 
@@ -35,11 +35,6 @@
                     <artifactId>netty-transport-native-epoll</artifactId>
                 </exclusion>
             </exclusions>
-        </dependency>
-        <dependency>
-            <groupId>org.apache.arrow</groupId>
-            <artifactId>flight-grpc</artifactId>
-            <version>${arrow.version}</version>
         </dependency>
         <dependency>
             <groupId>org.bouncycastle</groupId>

--- a/java/pom.xml
+++ b/java/pom.xml
@@ -11,8 +11,8 @@
 
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <arrow.version>3.0.0</arrow.version>
-        <dep.guava.version>20.0</dep.guava.version>
+        <arrow.version>11.0.0-20240312005600-b6b322df1a-dremio</arrow.version>
+        <dep.guava.version>33.1.0-jre</dep.guava.version>
         <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     </properties>
 
@@ -72,6 +72,16 @@
         </dependency>
 
     </dependencies>
+
+    <repositories>
+        <repository>
+            <snapshots>
+                <enabled>false</enabled>
+            </snapshots>
+            <id>dremio-public</id>
+            <url>https://repo.drem.io/content/repositories/internal-releases/</url>
+        </repository>
+    </repositories>
 
     <build>
         <plugins>

--- a/java/src/main/java/com/adhoc/flight/QueryRunner.java
+++ b/java/src/main/java/com/adhoc/flight/QueryRunner.java
@@ -119,6 +119,10 @@ public class QueryRunner {
         description = "The specific engine to run against.")
     public String engine;
 
+    @Parameter(names = {"-projectId", "--projectId"},
+        description = "Dremio Cloud project to connect to.")
+    public String projectId;
+
     @Parameter(names = {"-sp", "--sessionProperty"},
         description = "Key value pairs of SessionProperty, " +
           "example: -sp schema='Samples.\"samples.dremio.com\"' -sp key=value",
@@ -330,6 +334,7 @@ public class QueryRunner {
           ARGUMENTS.patOrAuthToken,
           ARGUMENTS.keystorePath, ARGUMENTS.keystorePass,
           ARGUMENTS.disableServerVerification,
+          ARGUMENTS.projectId,
           clientProperties,
           null);
     } else {
@@ -337,6 +342,7 @@ public class QueryRunner {
           ARGUMENTS.host, ARGUMENTS.port,
           ARGUMENTS.user, ARGUMENTS.pass,
           ARGUMENTS.patOrAuthToken,
+          ARGUMENTS.projectId,
           clientProperties,
           null);
     }

--- a/java/src/main/java/com/adhoc/flight/client/AdhocFlightClient.java
+++ b/java/src/main/java/com/adhoc/flight/client/AdhocFlightClient.java
@@ -26,10 +26,9 @@ import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Map;
-import java.util.Map.Entry;
 import java.util.concurrent.Callable;
 import java.util.function.Consumer;
+import java.util.stream.Collectors;
 
 import javax.annotation.Nullable;
 
@@ -46,7 +45,6 @@ import org.apache.arrow.flight.SessionOptionValue;
 import org.apache.arrow.flight.SessionOptionValueFactory;
 import org.apache.arrow.flight.SetSessionOptionsRequest;
 import org.apache.arrow.flight.SetSessionOptionsResult;
-import org.apache.arrow.flight.SetSessionOptionsResult.Error;
 import org.apache.arrow.flight.auth2.BasicAuthCredentialWriter;
 import org.apache.arrow.flight.auth2.BearerCredentialWriter;
 import org.apache.arrow.flight.auth2.ClientBearerHeaderHandler;
@@ -67,10 +65,11 @@ import com.google.common.base.Strings;
 import com.google.common.collect.ImmutableMap;
 
 /**
- * Adhoc Flight Client encapsulating an active FlightClient and a corresponding
- * CredentialCallOption with a bearer token for subsequent FlightRPC requests.
+ * Adhoc Flight Client encapsulating an active FlightClient and a corresponding CredentialCallOption
+ * with a bearer token for subsequent FlightRPC requests.
  */
 public final class AdhocFlightClient implements AutoCloseable {
+
   public static final String PROJECT_ID_KEY = "project_id";
 
   private final FlightClient client;
@@ -79,7 +78,7 @@ public final class AdhocFlightClient implements AutoCloseable {
   private final String projectId;
 
   AdhocFlightClient(final FlightClient client, final BufferAllocator allocator,
-                    final CredentialCallOption bearerToken, final String projectId) {
+      final CredentialCallOption bearerToken, final String projectId) {
     this.client = requireNonNull(client);
     this.allocator = requireNonNull(allocator);
     this.bearerToken = requireNonNull(bearerToken);
@@ -104,15 +103,15 @@ public final class AdhocFlightClient implements AutoCloseable {
    * @throws Exception RuntimeException if unable to access JKS with provided information.
    */
   public static AdhocFlightClient getEncryptedClient(BufferAllocator allocator,
-                                                     String host, int port,
-                                                     String user, String pass,
-                                                     String patOrAuthToken,
-                                                     String keyStorePath,
-                                                     String keyStorePass,
-                                                     boolean disableServerVerification,
-                                                     String projectId,
-                                                     HeaderCallOption clientProperties,
-                                                     List<FlightClientMiddleware.Factory> middlewares)
+      String host, int port,
+      String user, String pass,
+      String patOrAuthToken,
+      String keyStorePath,
+      String keyStorePass,
+      boolean disableServerVerification,
+      String projectId,
+      HeaderCallOption clientProperties,
+      List<FlightClientMiddleware.Factory> middlewares)
       throws Exception {
 
     final FlightClient.Builder flightClientBuilder = FlightClient.builder()
@@ -133,17 +132,17 @@ public final class AdhocFlightClient implements AutoCloseable {
       System.out.println("KeyStore password not provided. Defaulting to system KeyStore.");
     } else {
       flightClientBuilder
-        .trustedCertificates(EncryptedConnectionUtils.getCertificateStream(keyStorePath, keyStorePass));
+          .trustedCertificates(
+              EncryptedConnectionUtils.getCertificateStream(keyStorePath, keyStorePass));
     }
 
     return getClientHelper(
-      allocator,
-      host, port,
-      user, pass,
-      patOrAuthToken,
-      projectId,
-      clientProperties,
-      flightClientBuilder);
+        allocator,
+        user, pass,
+        patOrAuthToken,
+        projectId,
+        clientProperties,
+        flightClientBuilder);
   }
 
   /**
@@ -161,12 +160,12 @@ public final class AdhocFlightClient implements AutoCloseable {
    *         with bearer token for subsequent FlightRPC requests.
    */
   public static AdhocFlightClient getBasicClient(BufferAllocator allocator,
-                                                 String host, int port,
-                                                 String user, String pass,
-                                                 String patOrAuthToken,
-                                                 String projectId,
-                                                 HeaderCallOption clientProperties,
-                                                 List<FlightClientMiddleware.Factory> middlewares) {
+      String host, int port,
+      String user, String pass,
+      String patOrAuthToken,
+      String projectId,
+      HeaderCallOption clientProperties,
+      List<FlightClientMiddleware.Factory> middlewares) {
 
     final FlightClient.Builder flightClientBuilder = FlightClient.builder()
         .location(Location.forGrpcInsecure(host, port));
@@ -178,22 +177,20 @@ public final class AdhocFlightClient implements AutoCloseable {
     }
 
     return getClientHelper(
-      allocator,
-      host, port,
-      user, pass,
-      patOrAuthToken,
-      projectId,
-      clientProperties,
-      flightClientBuilder);
+        allocator,
+        user, pass,
+        patOrAuthToken,
+        projectId,
+        clientProperties,
+        flightClientBuilder);
   }
 
   private static AdhocFlightClient getClientHelper(BufferAllocator allocator,
-                                                   String host, int port,
-                                                   String user, String pass,
-                                                   String patOrAuthToken,
-                                                   String projectId,
-                                                   HeaderCallOption clientProperties,
-                                                   FlightClient.Builder builder) {
+      String user, String pass,
+      String patOrAuthToken,
+      String projectId,
+      HeaderCallOption clientProperties,
+      FlightClient.Builder builder) {
 
     if (Strings.isNullOrEmpty(patOrAuthToken) && Strings.isNullOrEmpty(pass)) {
       throw new IllegalArgumentException("No authentication method chosen.");
@@ -218,7 +215,8 @@ public final class AdhocFlightClient implements AutoCloseable {
       // Create a new instance of ClientIncomingAuthHeaderMiddleware.Factory. This factory creates
       // new instances of ClientIncomingAuthHeaderMiddleware. The middleware processes
       // username/password and bearer token authorization header authentication for this Flight Client.
-      authHeaderFactory = new ClientIncomingAuthHeaderMiddleware.Factory(new ClientBearerHeaderHandler());
+      authHeaderFactory = new ClientIncomingAuthHeaderMiddleware.Factory(
+          new ClientBearerHeaderHandler());
 
       // Adds ClientIncomingAuthHeaderMiddleware.Factory instance to the FlightClient builder.
       builder.intercept(authHeaderFactory);
@@ -230,18 +228,20 @@ public final class AdhocFlightClient implements AutoCloseable {
     if (!Strings.isNullOrEmpty(patOrAuthToken)) {
       credentials = authenticatePatOrAuthToken(flightClient, patOrAuthToken, clientProperties);
     } else {
-      credentials = authenticateUsernamePassword(flightClient, user, pass, authHeaderFactory, clientProperties);
+      credentials = authenticateUsernamePassword(flightClient, user, pass, authHeaderFactory,
+          clientProperties);
     }
 
     return new AdhocFlightClient(
-      flightClient,
-      allocator,
-      credentials,
-      projectId);
+        flightClient,
+        allocator,
+        credentials,
+        projectId);
   }
 
   /**
-   * Helper method to authenticate provided FlightClient instance against a Dremio Flight Server Endpoint.
+   * Helper method to authenticate provided FlightClient instance against a Dremio Flight Server
+   * Endpoint.
    *
    * @param client           the FlightClient instance to connect to Dremio.
    * @param user             the Dremio username.
@@ -251,9 +251,9 @@ public final class AdhocFlightClient implements AutoCloseable {
    * @return CredentialCallOption encapsulating the bearer token to use in subsequent requests.
    */
   public static CredentialCallOption authenticateUsernamePassword(FlightClient client,
-                                                  String user, String pass,
-                                                  ClientIncomingAuthHeaderMiddleware.Factory factory,
-                                                  HeaderCallOption clientProperties) {
+      String user, String pass,
+      ClientIncomingAuthHeaderMiddleware.Factory factory,
+      HeaderCallOption clientProperties) {
     final List<CallOption> callOptions = new ArrayList<>();
 
     // Add CredentialCallOption for authentication.
@@ -274,7 +274,6 @@ public final class AdhocFlightClient implements AutoCloseable {
     //    final HeaderCallOption routingCallOptions = new HeaderCallOption(callHeaders);
     //    callOptions.add(routingCallOptions);
 
-
     // If provided, add client properties to CallOptions.
     if (clientProperties != null) {
       callOptions.add(clientProperties);
@@ -290,15 +289,17 @@ public final class AdhocFlightClient implements AutoCloseable {
   }
 
   /**
-   * Helper method to authenticate provided FlightClient instance against a Dremio Flight Server Endpoint.
-   * @param client            the FlightClient instance to connect to Dremio.
-   * @param patOrAuthToken    the Personal Access token or OAuth2 token.
-   * @param clientProperties  client properties to set during authentication.
+   * Helper method to authenticate provided FlightClient instance against a Dremio Flight Server
+   * Endpoint.
+   *
+   * @param client           the FlightClient instance to connect to Dremio.
+   * @param patOrAuthToken   the Personal Access token or OAuth2 token.
+   * @param clientProperties client properties to set during authentication.
    * @return CredentialCallOption encapsulating the bearer token to use in subsequent requests.
    */
   public static CredentialCallOption authenticatePatOrAuthToken(FlightClient client,
-                                                                String patOrAuthToken,
-                                                                HeaderCallOption clientProperties) {
+      String patOrAuthToken,
+      HeaderCallOption clientProperties) {
     final List<CallOption> callOptions = new ArrayList<>();
 
     callOptions.add(new CredentialCallOption(new BearerCredentialWriter(patOrAuthToken)));
@@ -325,12 +326,13 @@ public final class AdhocFlightClient implements AutoCloseable {
    * @return a FlightInfo object.
    */
   public FlightInfo getInfo(String query, CallOption... options) {
-    return client.getInfo(FlightDescriptor.command(query.getBytes(StandardCharsets.UTF_8)), options);
+    return client.getInfo(FlightDescriptor.command(query.getBytes(StandardCharsets.UTF_8)),
+        options);
   }
 
   /**
-   * Make a FlightRPC getStream request based on the provided FlightInfo object. Retrieves
-   * result of the query previously prepared with getInfo.
+   * Make a FlightRPC getStream request based on the provided FlightInfo object. Retrieves result of
+   * the query previously prepared with getInfo.
    *
    * @param flightInfo the FlightInfo object encapsulating information for the server to identify
    *                   the prepared statement with.
@@ -344,8 +346,8 @@ public final class AdhocFlightClient implements AutoCloseable {
   private SetSessionOptionsRequest createSetSessionOption(String key, String value) {
     final SetSessionOptionsRequest setSessionOptionRequest =
         new SetSessionOptionsRequest(ImmutableMap.<String, SessionOptionValue>
-                builder().put(key,
-                              SessionOptionValueFactory.makeSessionOptionValue(value)).build());
+            builder().put(key,
+            SessionOptionValueFactory.makeSessionOptionValue(value)).build());
     return setSessionOptionRequest;
   }
 
@@ -355,8 +357,8 @@ public final class AdhocFlightClient implements AutoCloseable {
    *
    * @param query            the SQL query to execute.
    * @param headerCallOption client properties to execute provided SQL query with.
-   * @param fileToSaveTo     the file to which the binary data of the resulting {@link VectorSchemaRoot}
-   *                         should be saved.
+   * @param fileToSaveTo     the file to which the binary data of the resulting
+   *                         {@link VectorSchemaRoot} should be saved.
    * @param printToConsole   true - query results will be printed to console. false - no output.
    * @throws Exception if an error occurs during query execution.
    */
@@ -376,30 +378,25 @@ public final class AdhocFlightClient implements AutoCloseable {
   }
 
   /**
-   * A wrapper to create a flight session with associated session options around
-   * the associated callable.
+   * A wrapper to create a flight session with associated session options around the associated
+   * callable.
+   *
    * @param callable a call to execute flightthat session options will surround
-   * @param <V> type of the callable return value
    */
-  private <V> V runWithSessionOptions(final @Nullable HeaderCallOption headerCallOption,
-      Callable<V> callable) throws Exception {
-    final SetSessionOptionsResult res1 = client.setSessionOptions(
+  private void runWithSessionOptions(final @Nullable HeaderCallOption headerCallOption,
+      Callable<Void> callable) throws Exception {
+    final SetSessionOptionsResult optionsResult = client.setSessionOptions(
         createSetSessionOption(PROJECT_ID_KEY, projectId), bearerToken, headerCallOption);
 
-    if (res1.hasErrors()) {
+    if (optionsResult.hasErrors()) {
       // A session is only created if the session options are error free.
-      Map<String, SetSessionOptionsResult.Error> errors = res1.getErrors();
-      StringBuilder sb = new StringBuilder();
-      for (Entry<String, Error> error : errors.entrySet()) {
-        sb.append(error.toString() + "/n");
-      }
-      throw new RuntimeException(sb.toString());
+      String errorMessage = optionsResult.getErrors().entrySet().stream()
+          .map(Object::toString).collect(Collectors.joining(System.lineSeparator()));
+      throw new RuntimeException(errorMessage);
     }
 
     callable.call();
-
     client.closeSession(new CloseSessionRequest(), bearerToken, headerCallOption);
-    return null;
   }
 
   /**
@@ -408,14 +405,14 @@ public final class AdhocFlightClient implements AutoCloseable {
    *
    * @param query            the SQL query to execute.
    * @param headerCallOption client properties to execute provided SQL query with.
-   * @param fileToSaveTo     the file to which the binary data of the resulting {@link VectorSchemaRoot}
-   *                         should be saved.
+   * @param fileToSaveTo     the file to which the binary data of the resulting
+   *                         {@link VectorSchemaRoot} should be saved.
    * @throws Exception if an error occurs during query execution.
    */
   public void runQuery(final String query,
-                       final @Nullable HeaderCallOption headerCallOption,
-                       final @Nullable File fileToSaveTo,
-                       final boolean printToConsole) throws Exception {
+      final @Nullable HeaderCallOption headerCallOption,
+      final @Nullable File fileToSaveTo,
+      final boolean printToConsole) throws Exception {
 
     if (projectId != null) {
       runWithSessionOptions(headerCallOption,
@@ -430,12 +427,14 @@ public final class AdhocFlightClient implements AutoCloseable {
 
   @VisibleForTesting
   static void writeToOutputStream(final FlightStream flightStream, final BufferAllocator allocator,
-                                  final @Nullable OutputStream outputStream,
-                                  final Consumer<VectorSchemaRoot> batchConsumer)
+      final @Nullable OutputStream outputStream,
+      final Consumer<VectorSchemaRoot> batchConsumer)
       throws IOException {
-    try (final VectorSchemaRoot vectorSchemaRoot = VectorSchemaRoot.create(flightStream.getSchema(), allocator);
-         final ArrowStreamWriter arrowStreamWriter =
-             outputStream == null ? null : new ArrowStreamWriter(vectorSchemaRoot, null, outputStream)) {
+    try (final VectorSchemaRoot vectorSchemaRoot = VectorSchemaRoot.create(flightStream.getSchema(),
+        allocator);
+        final ArrowStreamWriter arrowStreamWriter =
+            outputStream == null ? null
+                : new ArrowStreamWriter(vectorSchemaRoot, null, outputStream)) {
       final VectorLoader vectorLoader = new VectorLoader(vectorSchemaRoot);
       if (arrowStreamWriter != null) {
         arrowStreamWriter.start();
@@ -444,7 +443,8 @@ public final class AdhocFlightClient implements AutoCloseable {
         if (!flightStream.hasRoot()) {
           break;
         }
-        try (final ArrowRecordBatch currentRecordBatch = new VectorUnloader(flightStream.getRoot()).getRecordBatch()) {
+        try (final ArrowRecordBatch currentRecordBatch = new VectorUnloader(
+            flightStream.getRoot()).getRecordBatch()) {
           if (batchConsumer != null) {
             batchConsumer.accept(flightStream.getRoot());
           }

--- a/java/src/main/java/com/adhoc/flight/client/AdhocFlightClient.java
+++ b/java/src/main/java/com/adhoc/flight/client/AdhocFlightClient.java
@@ -343,9 +343,9 @@ public final class AdhocFlightClient implements AutoCloseable {
 
   private SetSessionOptionsRequest createSetSessionOption(String key, String value) {
     final SetSessionOptionsRequest setSessionOptionRequest =
-        new SetSessionOptionsRequest(ImmutableMap.<String, SessionOptionValue>builder()
-          .put(key, SessionOptionValueFactory.makeSessionOptionValue(value))
-          .build());
+        new SetSessionOptionsRequest(ImmutableMap.<String, SessionOptionValue>
+                builder().put(key,
+                              SessionOptionValueFactory.makeSessionOptionValue(value)).build());
     return setSessionOptionRequest;
   }
 
@@ -383,7 +383,7 @@ public final class AdhocFlightClient implements AutoCloseable {
    */
   private <V> V runWithSessionOptions(final @Nullable HeaderCallOption headerCallOption,
       Callable<V> callable) throws Exception {
-    SetSessionOptionsResult res1 = client.setSessionOptions(
+    final SetSessionOptionsResult res1 = client.setSessionOptions(
         createSetSessionOption(PROJECT_ID_KEY, projectId), bearerToken, headerCallOption);
 
     if (res1.hasErrors()) {

--- a/java/src/test/java/com/adhoc/flight/TestAdhocFlightClient.java
+++ b/java/src/test/java/com/adhoc/flight/TestAdhocFlightClient.java
@@ -21,23 +21,31 @@ import static com.adhoc.flight.QueryRunner.KEY_ROUTING_QUEUE;
 import static com.adhoc.flight.QueryRunner.KEY_ROUTING_TAG;
 import static com.adhoc.flight.QueryRunner.KEY_SCHEMA;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.UUID;
 
 import org.apache.arrow.flight.CallHeaders;
 import org.apache.arrow.flight.CallInfo;
 import org.apache.arrow.flight.CallStatus;
 import org.apache.arrow.flight.FlightCallHeaders;
+import org.apache.arrow.flight.FlightClient;
 import org.apache.arrow.flight.FlightClientMiddleware;
 import org.apache.arrow.flight.FlightRuntimeException;
 import org.apache.arrow.flight.FlightStatusCode;
 import org.apache.arrow.flight.HeaderCallOption;
+import org.apache.arrow.flight.SessionOptionValue;
+import org.apache.arrow.flight.SetSessionOptionsRequest;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.util.AutoCloseables;
@@ -47,6 +55,10 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.runners.MockitoJUnitRunner;
 
 import com.adhoc.flight.client.AdhocFlightClient;
 import com.google.common.base.Strings;
@@ -54,6 +66,7 @@ import com.google.common.base.Strings;
 /**
  * Test Adhoc Flight Client with a live Dremio instance.
  */
+@RunWith(MockitoJUnitRunner.class)
 public class TestAdhocFlightClient {
   private static final String HOST = "localhost";
   private static final int PORT = 32010;
@@ -76,7 +89,11 @@ public class TestAdhocFlightClient {
     }
   };
 
+  @InjectMocks
   private AdhocFlightClient client;
+
+  FlightClient flightClient = mock(FlightClient.class);
+
   private BufferAllocator allocator;
 
   @Before
@@ -104,7 +121,7 @@ public class TestAdhocFlightClient {
    * @param patOrAuthToken  the personal access token or OAuth2 token.
    */
   private void createBasicFlightClient(String host, int port, String user, String pass, String patOrAuthToken) {
-    createBasicFlightClient(host, port, user, pass, patOrAuthToken, null);
+    createBasicFlightClient(host, port, user, pass, patOrAuthToken, null, null);
   }
 
   /**
@@ -120,9 +137,10 @@ public class TestAdhocFlightClient {
   private void createBasicFlightClient(String host, int port,
                                        String user, String pass,
                                        String patOrAuthToken,
+                                       String projectId,
                                        HeaderCallOption clientProperties) {
-    client = AdhocFlightClient.getBasicClient(allocator, host, port, user, pass, patOrAuthToken, null,
-        clientProperties, null);
+    client = AdhocFlightClient.getBasicClient(allocator, host, port, user, pass, patOrAuthToken,
+        projectId, clientProperties, null);
   }
 
   /**
@@ -173,7 +191,7 @@ public class TestAdhocFlightClient {
     final HeaderCallOption clientProperties = new HeaderCallOption(callHeaders);
 
     // Create FlightClient connecting to Dremio.
-    createBasicFlightClient(HOST, PORT, USERNAME, PASSWORD, null, clientProperties);
+    createBasicFlightClient(HOST, PORT, USERNAME, PASSWORD, null, null, clientProperties);
 
     // Create table
     client.runQuery(CREATE_TABLE, null, null, false);
@@ -253,6 +271,25 @@ public class TestAdhocFlightClient {
         () -> createBasicFlightClient(HOST, PORT, null, PASSWORD, null));
 
     assertTrue(exception.getMessage().contains("Username must be defined for password authentication"));
+  }
+
+  @Test
+  public void testSetSessionOptions() throws Exception {
+    final String mockProjectId = UUID.randomUUID().toString();
+    // Create FlightClient connecting to Dremio.
+    createBasicFlightClient(HOST, PORT, USERNAME, PASSWORD, null, mockProjectId, null);
+
+    // Select
+    client.runQuery(SIMPLE_QUERY, null, null, false);
+    final ArgumentCaptor<SetSessionOptionsRequest> argumentCaptor =
+        ArgumentCaptor.forClass(SetSessionOptionsRequest.class);
+    verify(flightClient).setSessionOptions(argumentCaptor.capture(), any(), any());
+    final List<SetSessionOptionsRequest> capturedRequest = argumentCaptor.getAllValues();
+    assertFalse(capturedRequest.isEmpty());
+    for (SetSessionOptionsRequest request : capturedRequest) {
+      final Map<String, SessionOptionValue> entry = request.getSessionOptions();
+      assertTrue(entry.containsKey(AdhocFlightClient.PROJECT_ID_KEY));
+    }
   }
 
   @Test

--- a/java/src/test/java/com/adhoc/flight/TestAdhocFlightClient.java
+++ b/java/src/test/java/com/adhoc/flight/TestAdhocFlightClient.java
@@ -80,7 +80,6 @@ public class TestAdhocFlightClient {
   public static final String DEFAULT_ROUTING_QUEUE = "Low Cost User Queries";
 
   public static final String CREATE_TABLE = "create table $scratch.simple_table as " + SIMPLE_QUERY;
-  public static final String CREATE_TABLE_NO_SCHEMA = "create table $scratch.simple_table as " + SIMPLE_QUERY;
   public static final String SIMPLE_QUERY_NO_SCHEMA = "SELECT * FROM simple_table";
   public static final String DROP_TABLE = "drop table $scratch.simple_table";
   public static final Map<String, String> EXPECTED_HEADERS = new HashMap<String, String>() {{

--- a/java/src/test/java/com/adhoc/flight/TestAdhocFlightClient.java
+++ b/java/src/test/java/com/adhoc/flight/TestAdhocFlightClient.java
@@ -121,7 +121,7 @@ public class TestAdhocFlightClient {
                                        String user, String pass,
                                        String patOrAuthToken,
                                        HeaderCallOption clientProperties) {
-    client = AdhocFlightClient.getBasicClient(allocator, host, port, user, pass, patOrAuthToken,
+    client = AdhocFlightClient.getBasicClient(allocator, host, port, user, pass, patOrAuthToken, null,
         clientProperties, null);
   }
 
@@ -141,7 +141,7 @@ public class TestAdhocFlightClient {
                                                                        HeaderCallOption clientProperties)
       throws Exception {
     client = AdhocFlightClient.getEncryptedClient(allocator, host, port, user, pass, null, null,
-      null, DISABLE_SERVER_VERIFICATION, clientProperties, null);
+      null, DISABLE_SERVER_VERIFICATION, null, clientProperties, null);
   }
 
   @Test
@@ -269,7 +269,7 @@ public class TestAdhocFlightClient {
 
     flightClientMiddlewareList.add(clientFactory);
 
-    client = AdhocFlightClient.getBasicClient(allocator, HOST, PORT, USERNAME, PASSWORD, null,
+    client = AdhocFlightClient.getBasicClient(allocator, HOST, PORT, USERNAME, PASSWORD, null, null,
       callOption, flightClientMiddlewareList);
 
     EXPECTED_HEADERS.forEach( (key, value) -> {

--- a/java/src/test/java/com/adhoc/flight/TestWithFlightServer.java
+++ b/java/src/test/java/com/adhoc/flight/TestWithFlightServer.java
@@ -95,7 +95,7 @@ public class TestWithFlightServer {
 
     final HeaderCallOption callOption = new HeaderCallOption(callHeaders);
 
-    client = AdhocFlightClient.getBasicClient(allocator, HOST, PORT, USERNAME, PASSWORD, null, callOption, null);
+    client = AdhocFlightClient.getBasicClient(allocator, HOST, PORT, USERNAME, PASSWORD, null, null, callOption, null);
 
     final Map<String, String> receivedHeaders = headerServerMiddlewareFactory.headers;
     EXPECTED_HEADERS_USER_PASS.forEach( (key, value) -> {
@@ -122,7 +122,7 @@ public class TestWithFlightServer {
 
     final HeaderCallOption callOption = new HeaderCallOption(callHeaders);
 
-    client = AdhocFlightClient.getBasicClient(allocator, HOST, PORT, USERNAME, null, PAT, callOption, null);
+    client = AdhocFlightClient.getBasicClient(allocator, HOST, PORT, USERNAME, null, PAT, null, callOption, null);
 
     final Map<String, String> receivedHeaders = headerServerMiddlewareFactory.headers;
     EXPECTED_HEADERS_PAT.forEach( (key, value) -> {

--- a/java/src/test/java/com/adhoc/flight/client/AdhocFlightClientProjectIdTest.java
+++ b/java/src/test/java/com/adhoc/flight/client/AdhocFlightClientProjectIdTest.java
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2017-2021 Dremio Corporation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.adhoc.flight.client;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyVararg;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import org.apache.arrow.flight.FlightClient;
+import org.apache.arrow.flight.FlightDescriptor;
+import org.apache.arrow.flight.FlightEndpoint;
+import org.apache.arrow.flight.FlightInfo;
+import org.apache.arrow.flight.Location;
+import org.apache.arrow.flight.SessionOptionValue;
+import org.apache.arrow.flight.SetSessionOptionsRequest;
+import org.apache.arrow.flight.SetSessionOptionsResult;
+import org.apache.arrow.flight.Ticket;
+import org.apache.arrow.flight.auth2.BasicAuthCredentialWriter;
+import org.apache.arrow.flight.grpc.CredentialCallOption;
+import org.apache.arrow.memory.RootAllocator;
+import org.apache.arrow.vector.types.pojo.Schema;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+
+public class AdhocFlightClientProjectIdTest {
+
+  @Test
+  public void testSetSessionOptions() throws Exception {
+    final String mockProjectId = UUID.randomUUID().toString();
+
+    FlightClient flightClient = mock(FlightClient.class);
+
+    AdhocFlightClient client = new AdhocFlightClient(flightClient,
+        new RootAllocator(Long.MAX_VALUE),
+        new CredentialCallOption(new BasicAuthCredentialWriter("login", "password")),
+        mockProjectId);
+
+    final ArgumentCaptor<SetSessionOptionsRequest> argumentCaptor =
+        ArgumentCaptor.forClass(SetSessionOptionsRequest.class);
+
+    when(flightClient.setSessionOptions(argumentCaptor.capture(), anyVararg())).thenReturn(
+        new SetSessionOptionsResult(new HashMap<>()));
+
+    when(flightClient.getStream(anyObject(), anyVararg())).thenThrow(
+        new UnsupportedOperationException());
+
+    byte[] randomBytes = "randomBytes".getBytes();
+    when(flightClient.getInfo(anyObject(), anyVararg())).thenReturn(
+        new FlightInfo(new Schema(new ArrayList<>()),
+            FlightDescriptor.command(randomBytes), Collections.singletonList(
+            new FlightEndpoint(new Ticket(randomBytes),
+                Location.forGrpcTls("localhost", 1234))), 12L, 12L));
+
+    try {
+      // Test the client without the execution stage
+      client.runQuery("any query", null, null, false);
+    } catch (UnsupportedOperationException ignored) {
+    }
+
+    final List<SetSessionOptionsRequest> capturedRequest = argumentCaptor.getAllValues();
+    assertFalse(capturedRequest.isEmpty());
+    for (SetSessionOptionsRequest request : capturedRequest) {
+      final Map<String, SessionOptionValue> entry = request.getSessionOptions();
+      assertTrue(entry.containsKey(AdhocFlightClient.PROJECT_ID_KEY));
+    }
+  }
+}


### PR DESCRIPTION
Adds a new option, -projectId, to the list of command line options that uses DoAction SessionOptions to set project id.
Review changes from old PR [link](https://github.com/dremio-hub/arrow-flight-client-examples/pull/58)