### PR TITLE
Add chunked data reading option for large datasets

### DIFF
--- a/python/example.py
+++ b/python/example.py
@@ -29,5 +29,25 @@ if __name__ == "__main__":
     # Get reader
     reader = dremio_flight_endpoint.get_reader(flight_client)
 
-    # Print out the data as a dataframe
-    print(reader.read_pandas())
+    # OPTION 1: Read all data at once (suitable for smaller datasets)
+    # Uncomment this line if working with manageable data sizes.
+    # print(reader.read_pandas())
+
+    # OPTION 2: Read data in chunks using RecordBatchReader (recommended for large datasets)
+    # Uncomment the following block if working with large datasets
+
+    """
+    # Convert the reader to a RecordBatchReader to read data in chunks
+    record_batch_reader = reader.to_reader()
+
+    # Iterate through each RecordBatch and convert to pandas DataFrame
+    try:
+        for record_batch in record_batch_reader:
+            # Convert the current RecordBatch to a pandas DataFrame
+            df = record_batch.to_pandas()
+            # Process or accumulate the DataFrame as needed
+            print(df)  # For demonstration, replace with the desired processing
+    except StopIteration:
+        # Raised when all data has been read
+        print("All data successfully loaded.")
+    """


### PR DESCRIPTION
This update provides an option for reading data in chunks using RecordBatchReader, which is beneficial when handling large datasets. The original read_pandas() method, which reads all data at once, remains available for smaller datasets where memory and stability constraints are less of a concern. By adding clear comments and two options—one for smaller and one for larger datasets—users can easily choose the most appropriate data loading method for their use case.

Changes include:

Option 1: read_pandas() for loading all data at once (suitable for smaller datasets).
Option 2: Chunked reading with RecordBatchReader, which processes data in RecordBatch chunks to reduce memory usage and improve stability in scenarios with high data volumes.
This approach helps prevent connection timeouts and memory issues, making the code more robust for various data sizes. Users can select their preferred method by uncommenting the relevant section.






