### PR TITLE
Add traceparent examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,5 @@ This repository provides sample Arrow Flight client applications in several lang
 - [java/flight-sql-jdbc-oauth](java/flight-sql-jdbc-oauth): Arrow Flight SQL JDBC Java examples for OAuth client credentials, token exchange, and Dremio user impersonation
 - [python](python): Python Arrow Flight client example
 - [go](go): Go Arrow Flight client example
+
+The Java, Python, and Go Flight client examples show how to send a W3C `traceparent` header with a user-provided trace ID. Each example also includes an option to set the sampled trace flag (`-01`) when required.

--- a/go/README.md
+++ b/go/README.md
@@ -31,6 +31,7 @@ Usage:
   example -h | --help
   example [--host=<hostname>] [--port=<port>] (--user=<username> --pass=<password> | --pat=<pat>)
           [--tls] [--certs=<path>] [--query <query>] [--project_id=<project_id>]
+          [--trace_id=<trace_id>] [--trace_sampled]
 
 Options:
   -h --help           Show this help.
@@ -43,6 +44,8 @@ Options:
   --tls               Enable encrypted connection.
   --certs=<path>      Path to trusted certificates for encrypted connection.
   --project_id=<project_id>   Dremio project ID
+  --trace_id=<trace_id>       W3C trace ID, exactly 32 lowercase hex characters.
+  --trace_sampled             Set W3C trace flags to sampled (-01). Defaults to unsampled (-00).
 ```
 
 ## Example
@@ -61,6 +64,12 @@ You can run a command similar to the following::
 go run . --host=<cloud.hostname> --port=443 --query="SELECT * FROM \"Samples\".\"samples.dremio.com\".\"NYC-taxi-trips\"" --tls --pat=<mypat> --project_id=<myprojectid>
 ```
 Here we're querying for a dataset called `NYC-taxi-trips`, in a source called `Samples`, in the `samples.dremio.com` folder.
+
+To send a W3C `traceparent` header with the Flight calls, provide a 32-character lowercase hex trace ID. The example generates a span ID and sends a header in the form `00-<trace_id>-<span_id>-<trace_flags>`. Use `--trace_sampled` when you need the trace flags byte to be sampled (`01`):
+
+```bash
+go run . --host=<cloud.hostname> --port=443 --query="SELECT 1" --tls --pat=<mypat> --trace_id=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa --trace_sampled
+```
 
 ## Tests
 

--- a/go/example.go
+++ b/go/example.go
@@ -15,10 +15,13 @@ package main
 import (
 	"arrow-flight-client-example/interfaces"
 	"context"
+	"crypto/rand"
 	"crypto/tls"
+	"encoding/hex"
 	"fmt"
 	"log"
 	"net"
+	"regexp"
 
 	"github.com/apache/arrow-go/v18/arrow/flight"
 	flightgen "github.com/apache/arrow-go/v18/arrow/flight/gen/flight"
@@ -36,6 +39,7 @@ Usage:
   example -h | --help
   example [--host=<hostname>] [--port=<port>] (--user=<username> --pass=<password> | --pat=<pat>)
           [--tls] [--certs=<path>] [--query <query>] [--project_id=<project_id>]
+          [--trace_id=<trace_id>] [--trace_sampled]
 
 Options:
   -h --help           Show this help.
@@ -47,7 +51,11 @@ Options:
   --query <query>     SQL Query to test.
   --tls               Enable encrypted connection.
   --certs=<path>      Path to trusted certificates for encrypted connection.
-  --project_id=<project_id>   Dremio project ID`
+  --project_id=<project_id>   Dremio project ID
+  --trace_id=<trace_id>       W3C trace ID, exactly 32 lowercase hex characters.
+  --trace_sampled             Set W3C trace flags to sampled (-01). Defaults to unsampled (-00).`
+
+var traceIDPattern = regexp.MustCompile(`^[0-9a-f]{32}$`)
 
 func WrapRecordReader(stream flight.FlightService_DoGetClient) (interfaces.RecordReader, error) {
 	return flight.NewRecordReader(stream)
@@ -116,6 +124,15 @@ func run(config FlightConfig, client flight.Client,
 	//  - routing-queue
 	ctx := metadata.NewOutgoingContext(context.TODO(),
 		metadata.Pairs("routing-tag", "test-routing-tag", "routing-queue", "Low Cost User Queries"))
+
+	if config.TraceID != "" {
+		traceparent, err := makeTraceparent(config.TraceID, config.TraceSampled)
+		if err != nil {
+			return err
+		}
+		ctx = metadata.AppendToOutgoingContext(ctx, "traceparent", traceparent)
+		log.Printf("[INFO] traceparent header configured: %s", traceparent)
+	}
 
 	var err error
 	if config.Pat != "" {
@@ -191,6 +208,24 @@ func run(config FlightConfig, client flight.Client,
 		log.Println(rec)
 	}
 	return nil
+}
+
+func makeTraceparent(traceID string, sampled bool) (string, error) {
+	if !traceIDPattern.MatchString(traceID) {
+		return "", fmt.Errorf("trace_id must be exactly 32 lowercase hex characters")
+	}
+
+	spanIDBytes := make([]byte, 8)
+	if _, err := rand.Read(spanIDBytes); err != nil {
+		return "", fmt.Errorf("failed to generate span ID: %w", err)
+	}
+
+	traceFlags := "00"
+	if sampled {
+		traceFlags = "01"
+	}
+
+	return fmt.Sprintf("00-%s-%s-%s", traceID, hex.EncodeToString(spanIDBytes), traceFlags), nil
 }
 
 func setSessionOptions(ctx context.Context, client flight.Client, projectID string) error {

--- a/go/flight_config.go
+++ b/go/flight_config.go
@@ -1,13 +1,15 @@
 package main
 
 type FlightConfig struct {
-	Host      string
-	Port      string
-	Pat       string
-	User      string
-	Pass      string
-	Query     string
-	TLS       bool `docopt:"--tls"`
-	Certs     string
-	ProjectID string `docopt:"--project_id"`
+	Host         string
+	Port         string
+	Pat          string
+	User         string
+	Pass         string
+	Query        string
+	TLS          bool `docopt:"--tls"`
+	Certs        string
+	ProjectID    string `docopt:"--project_id"`
+	TraceID      string `docopt:"--trace_id"`
+	TraceSampled bool   `docopt:"--trace_sampled"`
 }

--- a/java/flight-client/README.md
+++ b/java/flight-client/README.md
@@ -69,10 +69,31 @@ Arguments:
     -tls, --tls
       Enable encrypted connection.
       Defaults to false.
+    -traceId, --traceId
+      W3C trace ID, exactly 32 lowercase hex characters.
+    -traceSampled, --traceSampled
+      Set W3C trace flags to sampled (-01). Defaults to unsampled (-00).
     -user, --username
       Dremio username.
       Defaults to "dremio".
     -projectId, --projectId
       Dremio Cloud project to connect to.
       Default: default project for organization
+```
+
+### Traceparent Header
+
+To send a W3C `traceparent` header with the Flight calls, provide a 32-character lowercase hex trace ID. The client generates a span ID and sends a header in the form `00-<traceId>-<spanId>-<traceFlags>`.
+
+By default, the trace flags byte is unsampled (`00`). Use `-traceSampled` when you need the sampled flag (`01`):
+
+```bash
+java -jar target/java-flight-sample-client-application-1.0-SNAPSHOT-shaded.jar \
+  -query "SELECT 1" \
+  -host <DREMIO_HOSTNAME> \
+  -port 443 \
+  -tls \
+  -pat <PAT> \
+  -traceId aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa \
+  -traceSampled
 ```

--- a/java/flight-client/README.md
+++ b/java/flight-client/README.md
@@ -88,7 +88,8 @@ To send a W3C `traceparent` header with the Flight calls, provide a 32-character
 By default, the trace flags byte is unsampled (`00`). Use `-traceSampled` when you need the sampled flag (`01`):
 
 ```bash
-java -jar target/java-flight-sample-client-application-1.0-SNAPSHOT-shaded.jar \
+java --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED \
+  -jar target/java-flight-sample-client-application-1.0-SNAPSHOT-shaded.jar \
   -query "SELECT 1" \
   -host <DREMIO_HOSTNAME> \
   -port 443 \

--- a/java/flight-client/README.md
+++ b/java/flight-client/README.md
@@ -88,7 +88,7 @@ To send a W3C `traceparent` header with the Flight calls, provide a 32-character
 By default, the trace flags byte is unsampled (`00`). Use `-traceSampled` when you need the sampled flag (`01`):
 
 ```bash
-java --add-opens=java.base/java.nio=org.apache.arrow.memory.core,ALL-UNNAMED \
+java --add-opens=java.base/java.nio=ALL-UNNAMED \
   -jar target/java-flight-sample-client-application-1.0-SNAPSHOT-shaded.jar \
   -query "SELECT 1" \
   -host <DREMIO_HOSTNAME> \

--- a/java/flight-client/pom.xml
+++ b/java/flight-client/pom.xml
@@ -12,11 +12,32 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <arrow.version>18.0.0</arrow.version>
+        <netty.version>4.1.114.Final</netty.version>
         <dep.guava.version>33.3.0-jre</dep.guava.version>
         <checkstyle.failOnViolation>true</checkstyle.failOnViolation>
     </properties>
 
     <dependencies>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http2</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-http</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler-proxy</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-codec-socks</artifactId>
+            <version>${netty.version}</version>
+        </dependency>
         <dependency>
             <groupId>org.apache.arrow</groupId>
             <artifactId>flight-core</artifactId>

--- a/java/flight-client/src/main/java/com/adhoc/flight/QueryRunner.java
+++ b/java/flight-client/src/main/java/com/adhoc/flight/QueryRunner.java
@@ -17,6 +17,7 @@
 package com.adhoc.flight;
 
 import java.io.File;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -62,6 +63,8 @@ public class QueryRunner {
   public static final String KEY_ROUTING_TAG = "ROUTING_TAG";
   public static final String KEY_ROUTING_QUEUE = "ROUTING_QUEUE";
   public static final String KEY_ROUTING_ENGINE = "ROUTING_ENGINE";
+  public static final String KEY_TRACEPARENT = "traceparent";
+  private static final SecureRandom SECURE_RANDOM = new SecureRandom();
 
   /**
    * Class that holds all the command line arguments that can be used to run the
@@ -123,6 +126,14 @@ public class QueryRunner {
     @Parameter(names = {"-projectId", "--projectId"},
         description = "Dremio Cloud project to connect to.")
     public String projectId;
+
+    @Parameter(names = {"-traceId", "--traceId"},
+        description = "W3C trace ID, exactly 32 lowercase hex characters.")
+    public String traceId;
+
+    @Parameter(names = {"-traceSampled", "--traceSampled"},
+        description = "Set W3C trace flags to sampled (-01). Defaults to unsampled (-00).")
+    public boolean traceSampled = false;
 
     @Parameter(names = {"-sp", "--sessionProperty"},
         description = "Key value pairs of SessionProperty, " +
@@ -239,6 +250,12 @@ public class QueryRunner {
 
     if (!Strings.isNullOrEmpty(ARGUMENTS.engine)) {
       sessionPropertiesMap.put(KEY_ROUTING_ENGINE, ARGUMENTS.engine);
+    }
+
+    if (!Strings.isNullOrEmpty(ARGUMENTS.traceId)) {
+      final String traceparent = createTraceparent(ARGUMENTS.traceId, ARGUMENTS.traceSampled);
+      sessionPropertiesMap.put(KEY_TRACEPARENT, traceparent);
+      System.out.println(String.format("[INFO] Setting traceparent header: %s", traceparent));
     }
 
     final HeaderCallOption clientProperties = createClientProperties(sessionPropertiesMap);
@@ -368,6 +385,25 @@ public class QueryRunner {
     final CallHeaders callHeaders = new FlightCallHeaders();
     clientProperties.forEach(callHeaders::insert);
     return new HeaderCallOption(callHeaders);
+  }
+
+  private static String createTraceparent(String traceId, boolean sampled) {
+    if (!traceId.matches("[0-9a-f]{32}")) {
+      throw new IllegalArgumentException("traceId must be exactly 32 lowercase hex characters.");
+    }
+
+    final byte[] spanId = new byte[8];
+    SECURE_RANDOM.nextBytes(spanId);
+    final String traceFlags = sampled ? "01" : "00";
+    return String.format("00-%s-%s-%s", traceId, bytesToHex(spanId), traceFlags);
+  }
+
+  private static String bytesToHex(byte[] bytes) {
+    final StringBuilder builder = new StringBuilder(bytes.length * 2);
+    for (byte value : bytes) {
+      builder.append(String.format("%02x", value));
+    }
+    return builder.toString();
   }
 
   private static ConnectionTarget resolveConnectionTarget() {

--- a/python/README.md
+++ b/python/README.md
@@ -69,6 +69,8 @@ session_properties:
   - <str>
   - <str>
 engine: <str>
+trace_id: <str>
+trace_sampled: <bool>
 ```
 
 `hostname`
@@ -173,6 +175,31 @@ _type:_ string
 _required:_ False
 
 _description:_ The specific engine to run against. Only applicable to Dremio Cloud.
+
+`trace_id`
+
+_type:_ string
+
+_required:_ False
+
+_description:_ W3C trace ID to send in the `traceparent` Flight header. The value must be exactly 32 lowercase hex characters. The client generates a span ID and sends a header in the form `00-<trace_id>-<span_id>-<trace_flags>`.
+
+`trace_sampled`
+
+_type:_ boolean
+
+_required:_ False
+
+_default:_ False
+
+_description:_ When `true`, sets the W3C trace flags byte to sampled (`01`). When omitted or `false`, the trace flags byte is `00`. For example, `trace_id: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa` and `trace_sampled: true` produces a header like `traceparent: 00-aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa-<generated-span-id>-01`.
+
+Example:
+
+```
+trace_id: aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+trace_sampled: true
+```
 
 ## Description
 

--- a/python/config_template.yaml
+++ b/python/config_template.yaml
@@ -12,3 +12,5 @@
 #  - schema: Samples."samples.dremio.com"
 #  - <keep adding more session properties>
 #engine:
+#trace_id:
+#trace_sampled:

--- a/python/dremio-flight/dremio/arguments/parse.py
+++ b/python/dremio-flight/dremio/arguments/parse.py
@@ -38,6 +38,8 @@ options_default_validator = {
         "path_to_certs": str,
         "session_properties": list,
         "engine": str,
+        "trace_id": str,
+        "trace_sampled": bool,
     },
     "required": {
         "query": True,
@@ -116,10 +118,19 @@ def validate_auth_config(config: dict):
         )
 
 
+def validate_trace_config(config: dict):
+    trace_id = config.get("trace_id")
+    if trace_id is None:
+        return
+    if len(trace_id) != 32 or any(c not in "0123456789abcdef" for c in trace_id):
+        raise ValueError("The 'trace_id' option must be exactly 32 lowercase hex characters.")
+
+
 def validate_config(config: dict):
     validate_options_type(config)
     validate_required_options(config)
     validate_auth_config(config)
+    validate_trace_config(config)
     return
 
 

--- a/python/dremio-flight/dremio/flight/connection.py
+++ b/python/dremio-flight/dremio/flight/connection.py
@@ -14,6 +14,7 @@
   limitations under the License.
 """
 import logging
+import secrets
 from pyarrow import flight
 from dremio.middleware.auth import DremioClientAuthMiddlewareFactory
 from dremio.middleware.cookie import CookieMiddlewareFactory
@@ -36,6 +37,8 @@ class DremioFlightEndpointConnection:
         self.path_to_certs = connection_args.get("path_to_certs")
         self.session_properties = connection_args.get("session_properties")
         self.engine = connection_args.get("engine")
+        self.trace_id = connection_args.get("trace_id")
+        self.trace_sampled = connection_args.get("trace_sampled", False)
         self._set_headers()
 
     def connect(self) -> flight.FlightClient:
@@ -141,6 +144,13 @@ class DremioFlightEndpointConnection:
 
         if self.engine:
             self.headers.append((b"routing_engine", self.engine.encode("utf-8")))
+
+        if self.trace_id:
+            flags = "01" if self.trace_sampled else "00"
+            span_id = secrets.token_hex(8)
+            traceparent = f"00-{self.trace_id}-{span_id}-{flags}"
+            self.headers.append((b"traceparent", traceparent.encode("utf-8")))
+            logging.info("traceparent header configured: %s", traceparent)
 
         # Two WLM settings can be provided upon initial authentication with the Dremio Server Flight Endpoint:
         # routing_tag


### PR DESCRIPTION
## Summary
- add W3C traceparent header examples for Python, Go, and Java Flight clients
- add trace ID configuration/flags and sampled trace flag controls (`01`)
- document usage in each language README and the root README

## Validation
- `git diff --check`
- `python3 -m compileall python/dremio-flight/dremio python/example.py`
- `go build ./...`
- `mvn -q -pl flight-client test`

## Notes
- `go test ./...` requires generated mocks; `go/run_tests.sh` currently fails locally because `mockgen` is not installed.