### PR TITLE
[codex] Add JDBC software impersonation example

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,6 @@ This repository provides sample Arrow Flight client applications in several lang
 
 - [java](java): Overview of the Java example modules
 - [java/flight-client](java/flight-client): Arrow Flight RPC Java sample using `flight-core`
-- [java/flight-sql-jdbc-oauth](java/flight-sql-jdbc-oauth): Arrow Flight SQL JDBC Java examples for OAuth client credentials, token exchange, and Dremio user impersonation
+- [java/flight-sql-jdbc-oauth](java/flight-sql-jdbc-oauth): Arrow Flight SQL JDBC Java examples for OAuth client credentials, token exchange, OAuth user impersonation, and Dremio Software inbound impersonation
 - [python](python): Python Arrow Flight client example
 - [go](go): Go Arrow Flight client example

--- a/java/README.md
+++ b/java/README.md
@@ -5,12 +5,12 @@ This directory is the entrypoint for the Java examples in this repository.
 ## Available Examples
 
 - [flight-client](flight-client/README.md): Arrow Flight RPC Java sample using `flight-core`
-- [flight-sql-jdbc-oauth](flight-sql-jdbc-oauth/README.md): Java 11 Arrow Flight SQL JDBC examples for OAuth client credentials, token exchange, and Dremio user impersonation
+- [flight-sql-jdbc-oauth](flight-sql-jdbc-oauth/README.md): Java 11 Arrow Flight SQL JDBC examples for OAuth client credentials, token exchange, OAuth user impersonation, and Dremio Software inbound impersonation
 
 ## Build Entry Points
 
 - Legacy Flight client: `cd java/flight-client`
-- Flight SQL JDBC OAuth examples: `cd java/flight-sql-jdbc-oauth`
+- Flight SQL JDBC OAuth and Software impersonation examples: `cd java/flight-sql-jdbc-oauth`
 
 ## Notes
 

--- a/java/flight-sql-jdbc-oauth/README.md
+++ b/java/flight-sql-jdbc-oauth/README.md
@@ -1,10 +1,11 @@
 # Arrow Flight SQL JDBC OAuth Java Examples
 
-This module shows how to use the Arrow Flight SQL JDBC `19.0.0` driver with OAuth connection properties instead of manually calling Dremio's `/oauth/token` endpoint in application code. It covers:
+This module shows how to use the Arrow Flight SQL JDBC `19.0.0` driver with OAuth connection properties instead of manually calling Dremio's `/oauth/token` endpoint in application code. It also includes a Dremio Software basic-auth inbound impersonation example. It covers:
 
 - `client-credentials`
 - `token-exchange`
 - `dremio-impersonation`
+- `software-impersonation`
 
 ## Prerequisites
 
@@ -12,6 +13,7 @@ This module shows how to use the Arrow Flight SQL JDBC `19.0.0` driver with OAut
 - Maven 3.9+
 - A Dremio deployment with Arrow Flight SQL and OAuth enabled
 - A Dremio OAuth token endpoint, typically `http://<coordinator>:9047/oauth/token` or `https://<coordinator>/oauth/token`
+- For `software-impersonation`: Dremio Software only; requires version > 26.1.9. Use Dremio Software 26.1.10 or later.
 
 ## Build
 
@@ -52,6 +54,16 @@ All subcommands accept these options:
 
 Run `<jar> <subcommand> --help` to see all options for a specific subcommand.
 Run `<jar> --help` to list the available subcommands.
+
+Common connection options can also be set with environment variables:
+
+| Environment variable | CLI option |
+|----------------------|------------|
+| `DREMIO_HOST` | `--host` |
+| `DREMIO_PORT` | `--port` |
+| `DREMIO_QUERY` | `--query` |
+| `DREMIO_USE_ENCRYPTION` | `--use-encryption` |
+| `DREMIO_DISABLE_CERTIFICATE_VERIFICATION` | `--disable-certificate-verification` |
 
 ## Client Credentials
 
@@ -125,8 +137,92 @@ java --add-opens=java.base/java.nio=ALL-UNNAMED \
   --proxy-pat "$PROXY_USER_PAT"
 ```
 
+## Dremio Software Inbound Impersonation
+
+Dremio Software only; requires version > 26.1.9. Use Dremio Software 26.1.10 or later.
+
+This example uses Dremio Software username/password authentication with the Arrow Flight SQL JDBC driver and sets the JDBC connection property:
+
+```text
+impersonation_target=<target-user>
+```
+
+It does not use OAuth token exchange. The command validates inbound impersonation by running this query by default:
+
+```sql
+SELECT USER() AS user_name,
+       "SESSION_USER"() AS session_user_name,
+       "SYSTEM_USER"() AS system_user_name
+```
+
+The example prints the returned row and fails if `USER()`, `SESSION_USER()`, or `SYSTEM_USER()` returns anything other than the target user.
+
+Additional options:
+
+| Option | Environment variable | Description | Default |
+|--------|----------------------|-------------|---------|
+| `--username`, `--proxy-user` | `DREMIO_USERNAME` | Dremio proxy username | `dremio` |
+| `--password` | `DREMIO_PASSWORD` | Dremio proxy user password | Required |
+| `--target-user` | `DREMIO_TARGET_USER` | Dremio user to impersonate | Required |
+
+### Dremio Software Setup
+
+Before running the example, make sure the target user exists in Dremio Software. Then configure an inbound impersonation policy as an administrator:
+
+```sql
+ALTER SYSTEM SET "exec.impersonation.inbound_policies"='[
+  {
+    proxy_principals:{users:["<proxy_user>"]},
+    target_principals:{users:["<target_user>"]}
+  }
+]'
+```
+
+Verify the policy:
+
+```sql
+SELECT name, string_val
+FROM sys.options
+WHERE name = 'exec.impersonation.inbound_policies'
+```
+
+See the Dremio inbound impersonation documentation:
+https://docs.dremio.com/current/security/rbac/inbound-impersonation/
+
+### Run
+
+```bash
+java --add-opens=java.base/java.nio=ALL-UNNAMED \
+  -jar target/java-flight-sql-jdbc-oauth-examples-1.0-SNAPSHOT.jar \
+  software-impersonation \
+  --host automaster.drem.io \
+  --port 32010 \
+  --use-encryption \
+  --username dremio \
+  --password "$DREMIO_PASSWORD" \
+  --target-user impersonation_target_test
+```
+
+Expected successful output:
+
+```text
+Scenario: software-impersonation
+Flight SQL URL: jdbc:arrow-flight-sql://automaster.drem.io:32010
+Query: SELECT USER() AS user_name, "SESSION_USER"() AS session_user_name, "SYSTEM_USER"() AS system_user_name
+user_name	session_user_name	system_user_name
+impersonation_target_test	impersonation_target_test	impersonation_target_test
+Impersonation validation passed: USER(), SESSION_USER(), and SYSTEM_USER() all returned 'impersonation_target_test'.
+```
+
+Expected failure without an inbound impersonation policy:
+
+```text
+Proxy user '<proxy>' is not authorized to impersonate target user '<target>'.
+```
+
 ## Scenarios
 
 - `client-credentials`: Uses `oauth.flow=client_credentials`
 - `token-exchange`: Uses `oauth.flow=token_exchange`
 - `dremio-impersonation`: Uses `oauth.flow=token_exchange` with Dremio-specific subject and actor token types
+- `software-impersonation`: Uses username/password authentication with `impersonation_target=<target-user>`. Dremio Software only; requires version > 26.1.9.

--- a/java/flight-sql-jdbc-oauth/src/main/java/com/dremio/examples/jdbc/oauth/ConnectionParams.java
+++ b/java/flight-sql-jdbc-oauth/src/main/java/com/dremio/examples/jdbc/oauth/ConnectionParams.java
@@ -21,24 +21,39 @@ import com.beust.jcommander.Parameter;
 import java.util.Properties;
 
 final class ConnectionParams {
+  private static final String DEFAULT_QUERY = "SELECT 1 AS example_value";
+
+  ConnectionParams() {
+    this(DEFAULT_QUERY);
+  }
+
+  ConnectionParams(String defaultQuery) {
+    host = stringEnv("DREMIO_HOST", "localhost");
+    port = intEnv("DREMIO_PORT", 32010);
+    query = stringEnv("DREMIO_QUERY", defaultQuery);
+    useEncryption = booleanEnv("DREMIO_USE_ENCRYPTION", false);
+    disableCertificateVerification =
+        booleanEnv("DREMIO_DISABLE_CERTIFICATE_VERIFICATION", false);
+  }
+
   @Parameter(names = "--host", description = "Flight SQL hostname")
-  String host = "localhost";
+  String host;
 
   @Parameter(names = "--port", description = "Flight SQL port")
-  int port = 32010;
+  int port;
 
   @Parameter(names = "--query", description = "SQL query to run")
-  String query = "SELECT 1 AS example_value";
+  String query;
 
   @Parameter(names = "--max-rows", description = "Maximum rows to print")
   int maxRows = 10;
 
   @Parameter(names = "--use-encryption", description = "Enable encrypted connection")
-  boolean useEncryption = false;
+  boolean useEncryption;
 
   @Parameter(names = "--disable-certificate-verification",
       description = "Disable TLS server verification")
-  boolean disableCertificateVerification = false;
+  boolean disableCertificateVerification;
 
   @Parameter(names = "--tls-root-certs", description = "PEM file for TLS verification")
   String tlsRootCerts;
@@ -86,5 +101,29 @@ final class ConnectionParams {
     if (value != null) {
       properties.setProperty(name, value);
     }
+  }
+
+  static String stringEnv(String name, String defaultValue) {
+    final String value = System.getenv(name);
+    if (value == null || value.isEmpty()) {
+      return defaultValue;
+    }
+    return value;
+  }
+
+  private static int intEnv(String name, int defaultValue) {
+    final String value = System.getenv(name);
+    if (value == null || value.isEmpty()) {
+      return defaultValue;
+    }
+    return Integer.parseInt(value);
+  }
+
+  private static boolean booleanEnv(String name, boolean defaultValue) {
+    final String value = System.getenv(name);
+    if (value == null || value.isEmpty()) {
+      return defaultValue;
+    }
+    return Boolean.parseBoolean(value);
   }
 }

--- a/java/flight-sql-jdbc-oauth/src/main/java/com/dremio/examples/jdbc/oauth/FlightSqlExampleSupport.java
+++ b/java/flight-sql-jdbc-oauth/src/main/java/com/dremio/examples/jdbc/oauth/FlightSqlExampleSupport.java
@@ -23,6 +23,11 @@ import java.sql.ResultSet;
 import java.sql.ResultSetMetaData;
 import java.sql.SQLException;
 import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
 import java.util.Properties;
 
 final class FlightSqlExampleSupport {
@@ -51,10 +56,34 @@ final class FlightSqlExampleSupport {
     }
   }
 
-  private static void printRows(ResultSet resultSet, int maxRows) throws SQLException {
+  static void executeQueryAndValidateImpersonation(String scenario, String url, String query,
+      int maxRows, Properties properties, String targetUser) throws Exception {
+    Class.forName("org.apache.arrow.driver.jdbc.ArrowFlightJdbcDriver");
+
+    System.out.println("Scenario: " + scenario);
+    System.out.println("Flight SQL URL: " + url);
+    System.out.println("Query: " + query);
+
+    try (Connection connection = DriverManager.getConnection(url, properties);
+         Statement statement = connection.createStatement()) {
+      final boolean hasResults = statement.execute(query);
+      if (!hasResults) {
+        throw new IllegalStateException("Impersonation validation failed: statement completed "
+            + "without a result set.");
+      }
+
+      try (ResultSet resultSet = statement.getResultSet()) {
+        validateImpersonationResult(printRows(resultSet, maxRows), targetUser);
+      }
+    }
+  }
+
+  private static List<Map<String, String>> printRows(ResultSet resultSet, int maxRows)
+      throws SQLException {
     final ResultSetMetaData metadata = resultSet.getMetaData();
     final int columnCount = metadata.getColumnCount();
     int rowCount = 0;
+    final List<Map<String, String>> rows = new ArrayList<>();
 
     final StringBuilder header = new StringBuilder();
     for (int columnIndex = 1; columnIndex <= columnCount; columnIndex++) {
@@ -68,22 +97,59 @@ final class FlightSqlExampleSupport {
     while (resultSet.next()) {
       if (rowCount == maxRows) {
         System.out.println("Stopped after " + maxRows + " rows.");
-        return;
+        return rows;
       }
 
       final StringBuilder row = new StringBuilder();
+      final Map<String, String> values = new LinkedHashMap<>();
       for (int columnIndex = 1; columnIndex <= columnCount; columnIndex++) {
         if (columnIndex > 1) {
           row.append('\t');
         }
-        row.append(String.valueOf(resultSet.getObject(columnIndex)));
+        final String value = String.valueOf(resultSet.getObject(columnIndex));
+        row.append(value);
+        values.put(metadata.getColumnLabel(columnIndex).toLowerCase(Locale.ROOT), value);
       }
       System.out.println(row);
+      rows.add(values);
       rowCount++;
     }
 
     if (rowCount == 0) {
       System.out.println("Query returned no rows.");
     }
+    return rows;
+  }
+
+  private static void validateImpersonationResult(List<Map<String, String>> rows,
+      String targetUser) {
+    if (rows.isEmpty()) {
+      throw new IllegalStateException("Impersonation validation failed: query returned no rows.");
+    }
+
+    final Map<String, String> expectedColumns = new LinkedHashMap<>();
+    expectedColumns.put("user_name", "USER()");
+    expectedColumns.put("session_user_name", "SESSION_USER()");
+    expectedColumns.put("system_user_name", "SYSTEM_USER()");
+
+    for (int rowIndex = 0; rowIndex < rows.size(); rowIndex++) {
+      final Map<String, String> row = rows.get(rowIndex);
+      for (Map.Entry<String, String> expectedColumn : expectedColumns.entrySet()) {
+        final String value = row.get(expectedColumn.getKey());
+        if (value == null) {
+          throw new IllegalStateException("Impersonation validation failed: query must return "
+              + "column '" + expectedColumn.getKey() + "' for " + expectedColumn.getValue()
+              + ".");
+        }
+        if (!targetUser.equals(value)) {
+          throw new IllegalStateException("Impersonation validation failed: row "
+              + (rowIndex + 1) + " " + expectedColumn.getValue() + " returned '" + value
+              + "', expected '" + targetUser + "'.");
+        }
+      }
+    }
+
+    System.out.println("Impersonation validation passed: USER(), SESSION_USER(), and "
+        + "SYSTEM_USER() all returned '" + targetUser + "'.");
   }
 }

--- a/java/flight-sql-jdbc-oauth/src/main/java/com/dremio/examples/jdbc/oauth/OAuthJdbcExamples.java
+++ b/java/flight-sql-jdbc-oauth/src/main/java/com/dremio/examples/jdbc/oauth/OAuthJdbcExamples.java
@@ -29,12 +29,15 @@ public final class OAuthJdbcExamples {
     final ClientCredentialsCommand clientCreds = new ClientCredentialsCommand();
     final TokenExchangeCommand tokenExchange = new TokenExchangeCommand();
     final DremioImpersonationCommand impersonation = new DremioImpersonationCommand();
+    final SoftwareImpersonationCommand softwareImpersonation =
+        new SoftwareImpersonationCommand();
 
     final JCommander jCommander = JCommander.newBuilder()
         .programName("java --add-opens=java.base/java.nio=ALL-UNNAMED -jar <jar>")
         .addCommand(clientCreds)
         .addCommand(tokenExchange)
         .addCommand(impersonation)
+        .addCommand(softwareImpersonation)
         .build();
 
     if (isTopLevelHelp(args)) {
@@ -57,7 +60,12 @@ public final class OAuthJdbcExamples {
       return;
     }
 
-    if (isCommandHelpRequested(command, clientCreds, tokenExchange, impersonation)) {
+    if (isCommandHelpRequested(command, clientCreds, tokenExchange, impersonation,
+        softwareImpersonation)) {
+      if ("software-impersonation".equals(command)) {
+        System.out.println("Compatibility: Dremio Software only; requires version > 26.1.9 "
+            + "(26.1.10 or later).");
+      }
       jCommander.getCommands().get(command).usage();
       return;
     }
@@ -65,23 +73,37 @@ public final class OAuthJdbcExamples {
     final Properties properties;
     final ConnectionParams connection;
 
-    switch (command) {
-      case "client-credentials":
-        properties = clientCreds.toProperties();
-        connection = clientCreds.connection;
-        break;
-      case "token-exchange":
-        properties = tokenExchange.toProperties();
-        connection = tokenExchange.connection;
-        break;
-      case "dremio-impersonation":
-        properties = impersonation.toProperties();
-        connection = impersonation.connection;
-        break;
-      default:
-        jCommander.usage();
-        System.exit(1);
-        return;
+    try {
+      switch (command) {
+        case "client-credentials":
+          properties = clientCreds.toProperties();
+          connection = clientCreds.connection;
+          break;
+        case "token-exchange":
+          properties = tokenExchange.toProperties();
+          connection = tokenExchange.connection;
+          break;
+        case "dremio-impersonation":
+          properties = impersonation.toProperties();
+          connection = impersonation.connection;
+          break;
+        case "software-impersonation":
+          properties = softwareImpersonation.toProperties();
+          connection = softwareImpersonation.connection;
+          FlightSqlExampleSupport.executeQueryAndValidateImpersonation(command,
+              connection.connectionUrl(), connection.query, connection.maxRows, properties,
+              softwareImpersonation.targetUser);
+          return;
+        default:
+          jCommander.usage();
+          System.exit(1);
+          return;
+      }
+    } catch (ParameterException ex) {
+      System.err.println(ex.getMessage());
+      jCommander.getCommands().get(command).usage();
+      System.exit(1);
+      return;
     }
 
     FlightSqlExampleSupport.executeQuery(command, connection.connectionUrl(),
@@ -95,7 +117,8 @@ public final class OAuthJdbcExamples {
 
   private static boolean isCommandHelpRequested(String command,
       ClientCredentialsCommand clientCreds, TokenExchangeCommand tokenExchange,
-      DremioImpersonationCommand impersonation) {
+      DremioImpersonationCommand impersonation,
+      SoftwareImpersonationCommand softwareImpersonation) {
     switch (command) {
       case "client-credentials":
         return clientCreds.connection.help;
@@ -103,6 +126,8 @@ public final class OAuthJdbcExamples {
         return tokenExchange.connection.help;
       case "dremio-impersonation":
         return impersonation.connection.help;
+      case "software-impersonation":
+        return softwareImpersonation.connection.help;
       default:
         return false;
     }

--- a/java/flight-sql-jdbc-oauth/src/main/java/com/dremio/examples/jdbc/oauth/SoftwareImpersonationCommand.java
+++ b/java/flight-sql-jdbc-oauth/src/main/java/com/dremio/examples/jdbc/oauth/SoftwareImpersonationCommand.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package com.dremio.examples.jdbc.oauth;
+
+import com.beust.jcommander.Parameter;
+import com.beust.jcommander.ParameterException;
+import com.beust.jcommander.Parameters;
+import com.beust.jcommander.ParametersDelegate;
+import java.util.Properties;
+
+@Parameters(commandNames = "software-impersonation",
+    commandDescription = "Dremio Software inbound impersonation with basic auth "
+        + "(Software > 26.1.9 only)")
+final class SoftwareImpersonationCommand {
+  static final String DEFAULT_VALIDATION_QUERY = "SELECT USER() AS user_name, "
+      + "\"SESSION_USER\"() AS session_user_name, "
+      + "\"SYSTEM_USER\"() AS system_user_name";
+
+  @ParametersDelegate
+  ConnectionParams connection = new ConnectionParams(DEFAULT_VALIDATION_QUERY);
+
+  @Parameter(names = {"--username", "--proxy-user"},
+      description = "Dremio proxy username. Env: DREMIO_USERNAME")
+  String username = ConnectionParams.stringEnv("DREMIO_USERNAME", "dremio");
+
+  @Parameter(names = "--password", password = true,
+      description = "Dremio password for the proxy user. Env: DREMIO_PASSWORD")
+  String password = ConnectionParams.stringEnv("DREMIO_PASSWORD", null);
+
+  @Parameter(names = "--target-user",
+      description = "Dremio target user to impersonate. Env: DREMIO_TARGET_USER")
+  String targetUser = ConnectionParams.stringEnv("DREMIO_TARGET_USER", null);
+
+  Properties toProperties() {
+    if (password == null || password.isEmpty()) {
+      throw new ParameterException("--password or DREMIO_PASSWORD is required.");
+    }
+    if (targetUser == null || targetUser.isEmpty()) {
+      throw new ParameterException("--target-user or DREMIO_TARGET_USER is required.");
+    }
+
+    final Properties properties = connection.toProperties();
+    properties.setProperty("user", username);
+    properties.setProperty("password", password);
+    properties.setProperty("impersonation_target", targetUser);
+    return properties;
+  }
+}

--- a/java/flight-sql-jdbc-oauth/src/test/java/com/dremio/examples/jdbc/oauth/CommandPropertiesTest.java
+++ b/java/flight-sql-jdbc-oauth/src/test/java/com/dremio/examples/jdbc/oauth/CommandPropertiesTest.java
@@ -94,6 +94,39 @@ class CommandPropertiesTest {
   }
 
   @Test
+  void createsSoftwareImpersonationProperties() {
+    final SoftwareImpersonationCommand cmd = new SoftwareImpersonationCommand();
+    cmd.username = "proxy-user";
+    cmd.password = "proxy-password";
+    cmd.targetUser = "target-user";
+
+    final Properties properties = cmd.toProperties();
+
+    assertEquals("proxy-user", properties.getProperty("user"));
+    assertEquals("proxy-password", properties.getProperty("password"));
+    assertEquals("target-user", properties.getProperty("impersonation_target"));
+    assertEquals(SoftwareImpersonationCommand.DEFAULT_VALIDATION_QUERY, cmd.connection.query);
+  }
+
+  @Test
+  void rejectsSoftwareImpersonationWithoutPassword() {
+    final SoftwareImpersonationCommand cmd = new SoftwareImpersonationCommand();
+    cmd.password = null;
+    cmd.targetUser = "target-user";
+
+    assertThrows(ParameterException.class, cmd::toProperties);
+  }
+
+  @Test
+  void rejectsSoftwareImpersonationWithoutTargetUser() {
+    final SoftwareImpersonationCommand cmd = new SoftwareImpersonationCommand();
+    cmd.password = "proxy-password";
+    cmd.targetUser = null;
+
+    assertThrows(ParameterException.class, cmd::toProperties);
+  }
+
+  @Test
   void rejectsIncompleteTokenExchangeActorPair() {
     final TokenExchangeCommand cmd = new TokenExchangeCommand();
     cmd.oauth.tokenUri = "https://coordinator.example.com/oauth/token";


### PR DESCRIPTION
## Summary

Adds a Dremio Software inbound impersonation example to the Arrow Flight SQL JDBC module.

## Changes

- Adds a `software-impersonation` subcommand that authenticates with username/password and sets `impersonation_target`.
- Validates impersonation by checking `USER()`, `SESSION_USER()`, and `SYSTEM_USER()` all resolve to the target user.
- Adds environment variable defaults for common connection options and the Software impersonation command inputs.
- Documents Dremio Software setup, version compatibility (`> 26.1.9` / `26.1.10+`), expected success output, and expected authorization failure without policy.
- Adds unit tests for the new command properties and required arguments.

## Validation

- `mvn clean package` in `java/flight-sql-jdbc-oauth`
- CLI smoke: `software-impersonation --help`
- CLI smoke: missing password reports a concise usage error
- Live Dremio Software validation passed successfully with a proxy user and configured target user

Successful live validation output:

```text
Scenario: software-impersonation
Query: SELECT USER() AS user_name, "SESSION_USER"() AS session_user_name, "SYSTEM_USER"() AS system_user_name
user_name	session_user_name	system_user_name
impersonation_target_test	impersonation_target_test	impersonation_target_test
Impersonation validation passed: USER(), SESSION_USER(), and SYSTEM_USER() all returned 'impersonation_target_test'.
```